### PR TITLE
added DeepSeq instances

### DIFF
--- a/matplotlib.cabal
+++ b/matplotlib.cabal
@@ -25,6 +25,7 @@ library
   exposed-modules:     Graphics.Matplotlib.Internal
                      , Graphics.Matplotlib
   build-depends:       base >= 4.7 && < 5
+                     , deepseq
                      , process
                      , bytestring
                      , aeson

--- a/src/Graphics/Matplotlib.hs
+++ b/src/Graphics/Matplotlib.hs
@@ -444,7 +444,7 @@ zlabel label = mp # "ax.set_zlabel(" # raw label ## ")"
 
 setSizeInches w h = mp # "fig.set_size_inches(" # w # "," # h # ", forward=True)"
 
-tightLayout = mp # "fig.tight_layout()"
+tightLayout = mp # "fig.tight_layout(" ## ")"
 
 xkcd = mp # "plot.xkcd()"
 

--- a/src/Graphics/Matplotlib/Internal.hs
+++ b/src/Graphics/Matplotlib/Internal.hs
@@ -8,6 +8,7 @@ import System.IO.Temp
 import System.Process
 import Data.Aeson
 import Control.Monad
+import Control.DeepSeq
 import System.IO
 import qualified Data.ByteString.Lazy as B
 import Data.List
@@ -36,6 +37,9 @@ instance Monoid Matplotlib where
     mempty  = mp
     mappend = (%)
 
+instance NFData Matplotlib where
+    rnf (Matplotlib cs po re) = rnf cs `seq` rnf po `seq` rnf re
+
 -- | A maplotlib command, right now we have a very shallow embedding essentially
 -- dealing in strings containing python code as well as the ability to load
 -- data. The loaded data should be a json object.
@@ -43,6 +47,11 @@ data MplotCommand =
   LoadData B.ByteString
   | forall x. MplotImage x => LoadImage x
   | Exec { es :: String }
+
+instance NFData MplotCommand where
+    rnf (LoadData b) = rnf b
+    rnf (Exec es)    = rnf es
+    -- don't care too much about the LoadImage
 
 -- | Throughout the API we need to accept options in order to expose
 -- matplotlib's many configuration options.


### PR DESCRIPTION
This allows users to force the calculation of a `Matplotlib` instance.

I calculate the data of several subplots inside the `Matplotlib` instance, so this allows me to calculate all of them in parallel.