### PR TITLE
tight_layout has options

### DIFF
--- a/src/Graphics/Matplotlib.hs
+++ b/src/Graphics/Matplotlib.hs
@@ -444,7 +444,7 @@ zlabel label = mp # "ax.set_zlabel(" # raw label ## ")"
 
 setSizeInches w h = mp # "fig.set_size_inches(" # w # "," # h # ", forward=True)"
 
-tightLayout = mp # "fig.tight_layout()"
+tightLayout = mp # "fig.tight_layout(" ## ")"
 
 xkcd = mp # "plot.xkcd()"
 


### PR DESCRIPTION
`plt.tight_layout()` has a whole lot of useful options: https://matplotlib.org/users/tight_layout_guide.html

This just adds the `##` part to `tightLayout`.